### PR TITLE
Mirror events

### DIFF
--- a/kinto_changes/__init__.py
+++ b/kinto_changes/__init__.py
@@ -1,8 +1,16 @@
 import pkg_resources
+import pyramid.events
 from pyramid.settings import aslist
+from kinto.core import events
+from .listener import Listener
 
 #: Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
+
+
+def identity(f):
+    """Used as a fallback decorator if no statsd configured."""
+    return f
 
 
 def includeme(config):
@@ -20,3 +28,17 @@ def includeme(config):
         collections=aslist(collections))
 
     config.scan('kinto_changes.views')
+
+    listener = Listener(config)
+
+    decorate = identity
+    if config.registry.statsd:
+        key = 'plugins.kinto_changes'
+        decorate = config.registry.statsd.timer(key)
+
+    config.add_subscriber(decorate(listener.save_timestamps),
+                          pyramid.events.ApplicationCreated)
+
+    config.add_subscriber(decorate(listener.on_record_changed),
+                          events.ResourceChanged,
+                          for_resources=('record'))

--- a/kinto_changes/__init__.py
+++ b/kinto_changes/__init__.py
@@ -7,6 +7,13 @@ from .listener import Listener
 #: Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
 
+MONITOR_BUCKET = 'monitor'
+MONITOR_BUCKET_PATH = '/buckets/{}'.format(MONITOR_BUCKET)
+CHANGES_COLLECTION = 'changes'
+CHANGES_COLLECTION_PATH = '{}/collections/{}'.format(
+    MONITOR_BUCKET_PATH, CHANGES_COLLECTION)
+CHANGES_RECORDS_PATH = '{}/records'.format(CHANGES_COLLECTION_PATH)
+
 
 def identity(f):
     """Used as a fallback decorator if no statsd configured."""
@@ -36,7 +43,7 @@ def includeme(config):
         key = 'plugins.kinto_changes'
         decorate = config.registry.statsd.timer(key)
 
-    config.add_subscriber(decorate(listener.save_timestamps),
+    config.add_subscriber(decorate(listener.track_timestamps),
                           pyramid.events.ApplicationCreated)
 
     config.add_subscriber(decorate(listener.on_record_changed),

--- a/kinto_changes/listener.py
+++ b/kinto_changes/listener.py
@@ -23,15 +23,12 @@ class Listener(object):
         return self.registry.storage.collection_timestamp(parent_id=collection_uri,
                                                           collection_id='record')
 
-    def is_monitoring_collection(self, bucket_id, collection_id):
-        return is_monitoring_collection(self.registry, bucket_id, collection_id)
-
     def on_record_changed(self, event):
         bucket_id = event.payload['bucket_id']
         collection_id = event.payload['collection_id']
         timestamp = event.payload['timestamp']
 
-        if not self.is_monitoring_collection(bucket_id, collection_id):
+        if not is_monitoring_collection(self.registry, bucket_id, collection_id):
             return
 
         for change in event.impacted_records:

--- a/kinto_changes/listener.py
+++ b/kinto_changes/listener.py
@@ -1,0 +1,56 @@
+"""Listener that mirrors events from any collection into the changes collection."""
+
+from kinto.core import utils as core_utils
+from kinto.core.events import notify_resource_event, ACTIONS
+from .utils import monitored_collections, changes_record
+
+
+class Listener(object):
+    def __init__(self, config):
+        self.registry = config.registry
+        self.http_host = self.registry.settings.get('http_host') or ''
+        self.collection_timestamps = {}
+
+    def save_timestamps(self, event):
+        for (bucket_id, collection_id) in monitored_collections(self.registry):
+            timestamp = self.get_collection_timestamp(bucket_id, collection_id)
+            self.collection_timestamps[(bucket_id, collection_id)] = timestamp
+
+    def get_collection_timestamp(self, bucket_id, collection_id):
+        collection_uri = core_utils.instance_uri_registry(self.registry,
+                                                          'collection',
+                                                          bucket_id=bucket_id,
+                                                          id=collection_id)
+        return self.registry.storage.collection_timestamp(parent_id=collection_uri,
+                                                          collection_id='record')
+
+    def on_record_changed(self, event):
+        bucket_id = event.payload['bucket_id']
+        collection_id = event.payload['collection_id']
+        if (bucket_id, collection_id) not in monitored_collections(self.registry):
+            return
+
+        for change in event.impacted_records:
+            record = change.get('old') or change.get('new')
+
+            timestamp = self.get_collection_timestamp(bucket_id, collection_id)
+            # This might be the first we've seen of this collection.
+            old_timestamp = self.collection_timestamps.get((bucket_id, collection_id), None)
+            if timestamp == old_timestamp:
+                continue
+
+            # Synthesize event for /buckets/monitor/collections/changes record.
+            new = changes_record(event.request, self.http_host, bucket_id, collection_id, timestamp)
+            old = None
+            action = ACTIONS.CREATE
+            if old_timestamp:
+                action = ACTIONS.UPDATE
+                old = changes_record(event.request, self.http_host, bucket_id, collection_id, old_timestamp)
+
+            resource_data = {'bucket_id': 'monitor', 'collection_id': 'changes', 'id': new['id']}
+
+            notify_resource_event(event.request, '/buckets/monitor/collections/changes', timestamp, new,
+                                  action, old=old, resource_name='record', resource_data=resource_data
+            )
+
+            self.collection_timestamps[(bucket_id, collection_id)] = timestamp

--- a/kinto_changes/listener.py
+++ b/kinto_changes/listener.py
@@ -2,7 +2,7 @@
 
 from kinto.core import utils as core_utils
 from kinto.core.events import notify_resource_event, ACTIONS
-from .utils import monitored_collections, changes_record
+from .utils import monitored_collections, changes_record, is_monitoring_collection
 
 
 class Listener(object):
@@ -23,12 +23,15 @@ class Listener(object):
         return self.registry.storage.collection_timestamp(parent_id=collection_uri,
                                                           collection_id='record')
 
+    def is_monitoring_collection(self, bucket_id, collection_id):
+        return is_monitoring_collection(self.registry, bucket_id, collection_id)
+
     def on_record_changed(self, event):
         bucket_id = event.payload['bucket_id']
         collection_id = event.payload['collection_id']
         timestamp = event.payload['timestamp']
 
-        if (bucket_id, collection_id) not in monitored_collections(self.registry):
+        if not self.is_monitoring_collection(bucket_id, collection_id):
             return
 
         for change in event.impacted_records:

--- a/kinto_changes/listener.py
+++ b/kinto_changes/listener.py
@@ -31,8 +31,6 @@ class Listener(object):
             return
 
         for change in event.impacted_records:
-            record = change.get('old') or change.get('new')
-
             timestamp = self.get_collection_timestamp(bucket_id, collection_id)
             # This might be the first we've seen of this collection.
             old_timestamp = self.collection_timestamps.get((bucket_id, collection_id), None)
@@ -40,17 +38,21 @@ class Listener(object):
                 continue
 
             # Synthesize event for /buckets/monitor/collections/changes record.
-            new = changes_record(event.request, self.http_host, bucket_id, collection_id, timestamp)
+            new = changes_record(event.request, self.http_host,
+                                 bucket_id, collection_id, timestamp)
             old = None
             action = ACTIONS.CREATE
             if old_timestamp:
                 action = ACTIONS.UPDATE
-                old = changes_record(event.request, self.http_host, bucket_id, collection_id, old_timestamp)
+                old = changes_record(event.request, self.http_host,
+                                     bucket_id, collection_id, old_timestamp)
 
             resource_data = {'bucket_id': 'monitor', 'collection_id': 'changes', 'id': new['id']}
 
-            notify_resource_event(event.request, '/buckets/monitor/collections/changes', timestamp, new,
-                                  action, old=old, resource_name='record', resource_data=resource_data
+            notify_resource_event(
+                event.request, '/buckets/monitor/collections/changes',
+                timestamp, new, action, old=old,
+                resource_name='record', resource_data=resource_data
             )
 
             self.collection_timestamps[(bucket_id, collection_id)] = timestamp

--- a/kinto_changes/utils.py
+++ b/kinto_changes/utils.py
@@ -1,3 +1,6 @@
+import hashlib
+from uuid import UUID
+
 from pyramid.settings import aslist
 
 from kinto.core import utils as core_utils
@@ -20,3 +23,18 @@ def monitored_collections(registry):
             collections.append((matchdict['bucket_id'], matchdict['id']))
 
     return collections
+
+
+def changes_record(request, http_host, bucket_id, collection_id, timestamp):
+    """Generate a record for /buckets/monitor/collections/changes."""
+    collection_uri = core_utils.instance_uri(
+        request, 'collection', bucket_id=bucket_id, id=collection_id)
+    uniqueid = http_host + collection_uri
+    identifier = hashlib.md5(uniqueid.encode('utf-8')).hexdigest()
+    entry_id = str(UUID(identifier))
+
+    return dict(id=entry_id,
+                last_modified=timestamp,
+                bucket=bucket_id,
+                collection=collection_id,
+                host=http_host)

--- a/kinto_changes/utils.py
+++ b/kinto_changes/utils.py
@@ -14,9 +14,12 @@ def is_monitoring_collection(registry, bucket_id, collection_id):
         if resource_name == 'bucket' and bucket_id == matchdict['id']:
             return True
 
-        if (resource_name == 'collection' and
-              bucket_id == matchdict['bucket_id'] and
-              collection_id == matchdict['id']):
+        is_matching_collection = (
+            resource_name == 'collection' and
+            bucket_id == matchdict['bucket_id'] and
+            collection_id == matchdict['id']
+        )
+        if is_matching_collection:
             return True
 
 

--- a/kinto_changes/utils.py
+++ b/kinto_changes/utils.py
@@ -1,0 +1,22 @@
+from pyramid.settings import aslist
+
+from kinto.core import utils as core_utils
+
+
+def monitored_collections(registry):
+    storage = registry.storage
+    resources_uri = aslist(registry.settings.get('changes.resources', ''))
+    collections = []
+
+    for resource_uri in resources_uri:
+        resource_name, matchdict = core_utils.view_lookup_registry(registry, resource_uri)
+        if resource_name == 'bucket':
+            # Every collections in this bucket.
+            result, _ = storage.get_all(collection_id='collection',
+                                        parent_id=resource_uri)
+            collections.extend([(matchdict['id'], obj['id']) for obj in result])
+
+        elif resource_name == 'collection':
+            collections.append((matchdict['bucket_id'], matchdict['id']))
+
+    return collections

--- a/kinto_changes/utils.py
+++ b/kinto_changes/utils.py
@@ -14,7 +14,7 @@ def is_monitoring_collection(registry, bucket_id, collection_id):
         if resource_name == 'bucket' and bucket_id == matchdict['id']:
             return True
 
-        elif (resource_name == 'collection' and
+        if (resource_name == 'collection' and
               bucket_id == matchdict['bucket_id'] and
               collection_id == matchdict['id']):
             return True

--- a/kinto_changes/utils.py
+++ b/kinto_changes/utils.py
@@ -25,8 +25,9 @@ def monitored_collections(registry):
     return collections
 
 
-def changes_record(request, http_host, bucket_id, collection_id, timestamp):
+def changes_record(request, bucket_id, collection_id, timestamp):
     """Generate a record for /buckets/monitor/collections/changes."""
+    http_host = request.registry.settings.get('http_host') or ''
     collection_uri = core_utils.instance_uri(
         request, 'collection', bucket_id=bucket_id, id=collection_id)
     uniqueid = http_host + collection_uri

--- a/kinto_changes/utils.py
+++ b/kinto_changes/utils.py
@@ -6,6 +6,20 @@ from pyramid.settings import aslist
 from kinto.core import utils as core_utils
 
 
+def is_monitoring_collection(registry, bucket_id, collection_id):
+    resources_uri = aslist(registry.settings.get('changes.resources', ''))
+
+    for resource_uri in resources_uri:
+        resource_name, matchdict = core_utils.view_lookup_registry(registry, resource_uri)
+        if resource_name == 'bucket' and bucket_id == matchdict['id']:
+            return True
+
+        elif (resource_name == 'collection' and
+              bucket_id == matchdict['bucket_id'] and
+              collection_id == matchdict['id']):
+            return True
+
+
 def monitored_collections(registry):
     storage = registry.storage
     resources_uri = aslist(registry.settings.get('changes.resources', ''))

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -13,7 +13,7 @@ from kinto.core.authorization import RouteFactory
 from kinto.core.storage.memory import extract_record_set
 
 
-class PermissionsModel(object):
+class ChangesModel(object):
     id_field = 'id'
     modified_field = 'last_modified'
     deleted_field = 'deleted'
@@ -111,7 +111,7 @@ class Changes(resource.ShareableResource):
 
     def __init__(self, request, context=None):
         super(Changes, self).__init__(request, context)
-        self.model = PermissionsModel(request)
+        self.model = ChangesModel(request)
 
     @property
     def timestamp(self):

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -8,6 +8,7 @@ from kinto.core import utils as core_utils
 from kinto.core.authorization import RouteFactory
 from kinto.core.storage.memory import extract_record_set
 from .utils import monitored_collections, changes_record
+from . import CHANGES_RECORDS_PATH
 
 
 class ChangesModel(object):
@@ -18,9 +19,6 @@ class ChangesModel(object):
     def __init__(self, request):
         self.request = request
         self.storage = request.registry.storage
-
-        settings = request.registry.settings
-        self.http_host = settings.get('http_host') or ''
 
         self.__entries = None
 
@@ -48,10 +46,10 @@ class ChangesModel(object):
                 timestamp = self.storage.collection_timestamp(parent_id=collection_uri,
                                                               collection_id='record')
 
-                entry = changes_record(self.request, self.http_host,
+                entry = changes_record(self.request,
                                        bucket_id, collection_id, timestamp)
 
-                self.__entries[entry['id']] = entry
+                self.__entries[entry[self.id_field]] = entry
 
         return self.__entries.values()
 
@@ -74,7 +72,7 @@ class AnonymousRoute(RouteFactory):
 
 @resource.register(name='changes',
                    description='List of changes',
-                   collection_path='/buckets/monitor/collections/changes/records',
+                   collection_path=CHANGES_RECORDS_PATH,
                    record_path=None,
                    collection_methods=('GET',),
                    factory=AnonymousRoute)

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -2,7 +2,7 @@ import hashlib
 from uuid import UUID
 
 import colander
-from pyramid.security import NO_PERMISSION_REQUIRED, IAuthorizationPolicy
+from pyramid.security import IAuthorizationPolicy
 from pyramid.settings import aslist
 from zope.interface import implementer
 
@@ -104,7 +104,6 @@ class AnonymousRoute(RouteFactory):
                    collection_path='/buckets/monitor/collections/changes/records',
                    record_path=None,
                    collection_methods=('GET',),
-                   permission=NO_PERMISSION_REQUIRED,
                    factory=AnonymousRoute)
 class Changes(resource.ShareableResource):
 

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -1,6 +1,3 @@
-import hashlib
-from uuid import UUID
-
 import colander
 from pyramid.security import IAuthorizationPolicy
 from zope.interface import implementer
@@ -10,7 +7,7 @@ from kinto.core import resource
 from kinto.core import utils as core_utils
 from kinto.core.authorization import RouteFactory
 from kinto.core.storage.memory import extract_record_set
-from .utils import monitored_collections
+from .utils import monitored_collections, changes_record
 
 
 class ChangesModel(object):
@@ -51,17 +48,10 @@ class ChangesModel(object):
                 timestamp = self.storage.collection_timestamp(parent_id=collection_uri,
                                                               collection_id='record')
 
-                uniqueid = (self.http_host + collection_uri)
-                identifier = hashlib.md5(uniqueid.encode('utf-8')).hexdigest()
-                entry_id = str(UUID(identifier))
+                entry = changes_record(self.request, self.http_host,
+                                       bucket_id, collection_id, timestamp)
 
-                entry = dict(id=entry_id,
-                             last_modified=timestamp,
-                             bucket=bucket_id,
-                             collection=collection_id,
-                             host=self.http_host)
-
-                self.__entries[entry_id] = entry
+                self.__entries[entry['id']] = entry
 
         return self.__entries.values()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ iso8601==0.1.12
 jsonpatch==1.23
 jsonpointer==2.0
 jsonschema==2.6.0
-kinto==8.3.0
+kinto==10.0.0
 logging-color-formatter==1.0.2
 PasteDeploy==1.5.2
 plaster==1.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('CHANGELOG.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'kinto>=7.0.0'
+    'kinto>=10.0.0'
 ]
 
 test_requirements = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,6 +28,7 @@ class BaseWebTest(CoreWebTest):
         config = configparser.ConfigParser()
         config.read(ini_path)
         settings = dict(config.items('app:main'))
+        settings.update(extras or {})
         return settings
 
     def setUp(self):

--- a/tests/listener.py
+++ b/tests/listener.py
@@ -1,0 +1,2 @@
+def load_from_config():
+    return ()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,40 @@
+import mock
+import unittest
+
+from . import BaseWebTest
+
+SAMPLE_RECORD = {'data': {'dev-edition': True}}
+
+
+class RedirectEventsTest(BaseWebTest, unittest.TestCase):
+    changes_uri = '/buckets/monitor/collections/changes/records'
+    records_uri = '/buckets/blocklists/collections/certificates/records'
+
+    @classmethod
+    def make_app(cls, *args, **kwargs):
+        with mock.patch('tests.listener.load_from_config') as listener_loader:
+            cls.listener = listener_loader.return_value
+            return super(RedirectEventsTest, cls).make_app(*args, **kwargs)
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super(RedirectEventsTest, cls).get_app_settings(extras)
+        settings['event_listeners'] = 'tests.listener'
+        return settings
+
+    def setUp(self):
+        super(RedirectEventsTest, self).setUp()
+        self.registry = self.app.app.registry
+
+    def test_generate_event(self):
+        self.app.post_json(self.records_uri, SAMPLE_RECORD,
+                           headers=self.headers)
+        events = [call[0][0] for call in self.listener.call_args_list]
+        monitor_changes_events = [e for e in events
+                                  if e.payload.get('bucket_id') == 'monitor' and
+                                  e.payload.get('collection_id') == 'changes']
+        self.assertEqual(len(monitor_changes_events), 1)
+        event = monitor_changes_events[0]
+        self.assertEqual([r['new']['id'] for r in event.impacted_records],
+                         ['470119ee-115b-8f9c-f56b-afb824183411']  # ID for buckets/blocklists/collections/certificates
+        )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -56,6 +56,45 @@ class RedirectEventsTest(BaseWebTest, unittest.TestCase):
                                   e.payload.get('collection_id') == 'changes']
         self.assertEqual(len(monitor_changes_events), 0)
 
+    def test_scan_timestamps_on_startup(self):
+        self.create_collection('blocklists', 'pinning')
+        res = self.app.get('/buckets/blocklists/collections/pinning/records', headers=self.headers)
+        last_modified = int(res.headers['ETag'][1:-1])
+
+        old_storage = self.storage
+        old_permission = self.permission
+
+        def restore_storage(config):
+            """Bring old app's storage/permission (memory-based) over to a new app.
+
+            This lets us test initialization in the case of existing collections."""
+            config.registry.storage = old_storage
+            config.registry.permission = old_permission
+
+        with mock.patch('tests.test_events', restore_storage):
+            self.app = self.make_app({
+                'kinto.includes': 'tests.test_events kinto_changes'
+            })
+
+        self.app.post_json('/buckets/blocklists/collections/pinning/records', SAMPLE_RECORD,
+                           headers=self.headers)
+        events = [call[0][0] for call in self.listener.call_args_list]
+        monitor_changes_events = [e for e in events
+                                  if e.payload.get('bucket_id') == 'monitor' and
+                                  e.payload.get('collection_id') == 'changes']
+        self.assertEqual(len(monitor_changes_events), 1)
+        event = monitor_changes_events[0]
+
+        # ID for buckets/blocklists/collections/pinning
+        actual_impacted_record_ids = ['c5b1aefc-bbcc-af1f-df42-73e219236f23']
+
+        self.assertEqual(
+            [r['new']['id'] for r in event.impacted_records],
+            actual_impacted_record_ids
+        )
+        self.assertEqual(event.impacted_records[0]['old']['last_modified'], last_modified)
+
+
 class StatsdTest(BaseWebTest, unittest.TestCase):
     def test_statsd_wraps_subscriber(self):
         config = mock.MagicMock()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,10 +8,12 @@ from kinto_changes import includeme
 
 SAMPLE_RECORD = {'data': {'dev-edition': True}}
 
+
 def monitor_changes_events(events):
     return [e for e in events
             if e.payload.get('bucket_id') == 'monitor' and
             e.payload.get('collection_id') == 'changes']
+
 
 class RedirectEventsTest(BaseWebTest):
     changes_uri = '/buckets/monitor/collections/changes/records'
@@ -27,7 +29,10 @@ class RedirectEventsTest(BaseWebTest):
     def get_app_settings(cls, extras=None):
         settings = super(RedirectEventsTest, cls).get_app_settings(extras)
         settings['event_listeners'] = 'tests.listener'
-        settings['kinto.changes.resources'] = '/buckets/blocklists /buckets/fennec/collections/fonts'
+        settings['kinto.changes.resources'] = ' '.join([
+            '/buckets/blocklists',
+            '/buckets/fennec/collections/fonts'
+        ])
         return settings
 
     def setUp(self):
@@ -36,7 +41,8 @@ class RedirectEventsTest(BaseWebTest):
         self.listener.call_args_list = []
 
     def assert_event_is_for_collection(self, event, bucket_id, collection_id):
-        uniqueid = 'www.kinto-storage.org/buckets/{}/collections/{}'.format(bucket_id, collection_id)
+        uniqueid = 'www.kinto-storage.org/buckets/{}/collections/{}'.format(
+            bucket_id, collection_id)
         event_id = hashlib.md5(uniqueid.encode('utf-8')).hexdigest()
         event_id = str(UUID(event_id))
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,7 @@ import mock
 import unittest
 
 from . import BaseWebTest
+from kinto_changes import includeme
 
 SAMPLE_RECORD = {'data': {'dev-edition': True}}
 
@@ -25,6 +26,7 @@ class RedirectEventsTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super(RedirectEventsTest, self).setUp()
         self.registry = self.app.app.registry
+        self.listener.call_args_list = []
 
     def test_generate_event(self):
         self.app.post_json(self.records_uri, SAMPLE_RECORD,
@@ -43,3 +45,25 @@ class RedirectEventsTest(BaseWebTest, unittest.TestCase):
             [r['new']['id'] for r in event.impacted_records],
             actual_impacted_record_ids
         )
+
+    def test_ignore_event_for_unmonitored(self):
+        self.create_collection('foo', 'certificates')
+        self.app.post_json('/buckets/foo/collections/certificates/records',
+                           SAMPLE_RECORD, headers=self.headers)
+        events = [call[0][0] for call in self.listener.call_args_list]
+        monitor_changes_events = [e for e in events
+                                  if e.payload.get('bucket_id') == 'monitor' and
+                                  e.payload.get('collection_id') == 'changes']
+        self.assertEqual(len(monitor_changes_events), 0)
+
+class StatsdTest(BaseWebTest, unittest.TestCase):
+    def test_statsd_wraps_subscriber(self):
+        config = mock.MagicMock()
+        config.settings = {}
+        statsd = config.registry.statsd
+        statsd_decorate = statsd.timer.return_value
+
+        includeme(config)
+        self.assertEqual(statsd.timer.call_args_list[0][0][0], 'plugins.kinto_changes')
+        # Check that we're monitoring some calls.
+        self.assertTrue(statsd_decorate.call_count >= 2)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -35,6 +35,11 @@ class RedirectEventsTest(BaseWebTest, unittest.TestCase):
                                   e.payload.get('collection_id') == 'changes']
         self.assertEqual(len(monitor_changes_events), 1)
         event = monitor_changes_events[0]
-        self.assertEqual([r['new']['id'] for r in event.impacted_records],
-                         ['470119ee-115b-8f9c-f56b-afb824183411']  # ID for buckets/blocklists/collections/certificates
+
+        # ID for buckets/blocklists/collections/certificates
+        actual_impacted_record_ids = ['470119ee-115b-8f9c-f56b-afb824183411']
+
+        self.assertEqual(
+            [r['new']['id'] for r in event.impacted_records],
+            actual_impacted_record_ids
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+import mock
+import unittest
+
+from pyramid.request import Request
+
+from kinto_changes.utils import changes_record
+
+
+class ChangesRecordTest(unittest.TestCase):
+    def test_single_hardcoded(self):
+        request = Request.blank(path='/')
+        request.route_path = mock.Mock()
+        request.route_path.return_value = '/buckets/a/collections/b'
+        timestamp = 1525457597166
+        entry = changes_record(request, '', 'a', 'b', timestamp)
+
+        self.assertEqual(entry, {
+            "bucket": "a",
+            "collection": "b",
+            "host": "",
+            "id": "9527d115-6191-fa49-a530-8fbfc4997755",
+            "last_modified": timestamp
+        })
+
+    def test_another_hardcoded(self):
+        request = Request.blank(path='/')
+        request.route_path = mock.Mock()
+        request.route_path.return_value = '/buckets/a/collections/b'
+        timestamp = 1525457597166
+        entry = changes_record(request, 'https://localhost:443', 'a', 'b', timestamp)
+
+        self.assertEqual(entry, {
+            "bucket": "a",
+            "collection": "b",
+            "host": "https://localhost:443",
+            "id": "fa48a96d-1600-f561-8645-3395acb08a5a",
+            "last_modified": timestamp
+        })

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,8 +11,10 @@ class ChangesRecordTest(unittest.TestCase):
         request = Request.blank(path='/')
         request.route_path = mock.Mock()
         request.route_path.return_value = '/buckets/a/collections/b'
+        request.registry = mock.Mock()
+        request.registry.settings = {}
         timestamp = 1525457597166
-        entry = changes_record(request, '', 'a', 'b', timestamp)
+        entry = changes_record(request, 'a', 'b', timestamp)
 
         self.assertEqual(entry, {
             "bucket": "a",
@@ -26,8 +28,10 @@ class ChangesRecordTest(unittest.TestCase):
         request = Request.blank(path='/')
         request.route_path = mock.Mock()
         request.route_path.return_value = '/buckets/a/collections/b'
+        request.registry = mock.Mock()
+        request.registry.settings = {'http_host': 'https://localhost:443'}
         timestamp = 1525457597166
-        entry = changes_record(request, 'https://localhost:443', 'a', 'b', timestamp)
+        entry = changes_record(request, 'a', 'b', timestamp)
 
         self.assertEqual(entry, {
             "bucket": "a",


### PR DESCRIPTION
This doesn't work so far because:

- kinto.events still needs some changes which are (at the moment) buried in https://github.com/Kinto/kinto/pull/1648
- Using instance_uri on initialization doesn't work because plugins are included before kinto views (but after kinto.core views). There's also something unfortunate here where I have to call `config.commit()` in order to actually use the views that have been set up so far. I'm open to suggestions about how better to do this. I don't think it's possible to detect that a record change has caused a `collection_timestamp` change in an event listener in any other way..