### PR TITLE
Explicitly avoid action during a migrate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Don't do anything during a ``migrate`` command (fixes #43).
 
 
 1.2.0 (2018-09-06)

--- a/kinto_changes/__init__.py
+++ b/kinto_changes/__init__.py
@@ -24,6 +24,13 @@ def includeme(config):
     settings = config.get_settings()
     collections = settings.get('changes.resources', [])
 
+    # Don't do anything on a migration command.
+    # This is helpful because we try to get a snapshot of the database
+    # when the application is created. But if we're doing a migrate,
+    # there may not be a database.
+    if config.registry.settings.get('command') == 'migrate':
+        return
+
     config.add_api_capability(
         "changes",
         version=__version__,

--- a/kinto_changes/__init__.py
+++ b/kinto_changes/__init__.py
@@ -28,7 +28,7 @@ def includeme(config):
     # This is helpful because we try to get a snapshot of the database
     # when the application is created. But if we're doing a migrate,
     # there may not be a database.
-    if config.registry.settings.get('command') == 'migrate':
+    if getattr(config.registry, 'command') == 'migrate':
         return
 
     config.add_api_capability(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ iso8601==0.1.12
 jsonpatch==1.23
 jsonpointer==2.0
 jsonschema==2.6.0
-kinto==10.0.0
+kinto==10.1.0
 logging-color-formatter==1.0.2
 PasteDeploy==1.5.2
 plaster==1.0

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -138,7 +138,7 @@ class DontMigrateTest(BaseWebTest, unittest.TestCase):
     def test_migrate_does_nothing(self):
         config = mock.MagicMock()
         config.settings = {}
-        config.registry.settings = {'command': 'migrate'}
+        config.registry.command = 'migrate'
 
         includeme(config)
         self.assertNotIn('changes', config.capabilities)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -132,3 +132,13 @@ class StatsdTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(statsd.timer.call_args_list[0][0][0], 'plugins.kinto_changes')
         # Check that we're monitoring some calls.
         self.assertTrue(statsd_decorate.call_count >= 2)
+
+
+class DontMigrateTest(BaseWebTest, unittest.TestCase):
+    def test_migrate_does_nothing(self):
+        config = mock.MagicMock()
+        config.settings = {}
+        config.registry.settings = {'command': 'migrate'}
+
+        includeme(config)
+        self.assertNotIn('changes', config.capabilities)


### PR DESCRIPTION
Depends on Kinto/kinto#1762.

Fixes #43.

- [x] Add test