### PR TITLE
Set different cache control headers if cache busting querystring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 
 **New feature**
 
-- Do not send ``Cache-Control`` headers if querystring or concurrency control request headers are sent (#66)
+- Send ``Cache-Control`` headers if cache busting query parameters or concurrency control request headers are sent (#66)
 
 2.0.0 (2019-01-15)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New feature**
 
+- Do not send ``Cache-Control`` headers if querystring or concurrency control request headers are sent (#66)
 
 2.0.0 (2019-01-15)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -47,9 +47,12 @@ Like `cache control in Kinto collections <https://kinto.readthedocs.io/en/stable
 
     kinto.monitor.changes.record_cache_expires_seconds = 60
 
-.. important::
+If cache busting query parameters then responses can be cached more agressively.
+If the setting below is set then a different cache control expiration will be set:
 
-    The ``Cache-Control`` header won't be sent if some querystring params or concurrency control request headers are sent.
+.. code-block:: ini
+
+    kinto.monitor.changes.record_cache_maximum_expires_seconds = 3600
 
 
 Advanced options

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,10 @@ Like `cache control in Kinto collections <https://kinto.readthedocs.io/en/stable
 
     kinto.monitor.changes.record_cache_expires_seconds = 60
 
+.. important::
+
+    The ``Cache-Control`` header won't be sent if some querystring params or concurrency control request headers are sent.
+
 
 Advanced options
 ''''''''''''''''

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -92,17 +92,15 @@ class Changes(resource.Resource):
         return result
 
     def _handle_cache_expires(self, response):
-        # If the client sends some querystring parameters or some concurrency-control headers
-        # then we do not send a specific cache control header.
-        # In production, we set monitor/changes TTL to 1 min and default TTL to 1 hour.
-        # With this code and the production config, the clients that don't send cache busting
-        # query params get fresh data (1min) and the clients that send quey params and headers
-        # are likely to get the cached response for the values they specified.
-        has_querystring = len(self.request.GET) > 0
-        has_etag_headers = (self.request.headers.get("If-None-Match") or
-                            self.request.headers.get("If-Match"))
-        setting = '{}.{}.record_cache_expires_seconds'.format(MONITOR_BUCKET, CHANGES_COLLECTION)
-        if not has_querystring and not has_etag_headers:
-            cache_expires = self.request.registry.settings.get(setting)
-            if cache_expires is not None:
-                response.cache_expires(seconds=int(cache_expires))
+        # If the client sends cache busting query parameters, then we can cache more
+        # aggressively.
+        settings = self.request.registry.settings
+        prefix = f'{MONITOR_BUCKET}.{CHANGES_COLLECTION}.record_cache'
+        default_expires = settings.get(f'{prefix}_expires_seconds')
+        maximum_expires = settings.get(f'{prefix}_maximum_expires_seconds', default_expires)
+
+        has_cache_busting = "_expected" in self.request.GET
+        cache_expires = maximum_expires if has_cache_busting else default_expires
+
+        if cache_expires is not None:
+            response.cache_expires(seconds=int(cache_expires))

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -147,3 +147,7 @@ class CacheExpiresTest(BaseWebTest, unittest.TestCase):
     def test_cache_expires_headers_are_supported(self):
         resp = self.app.get(self.changes_uri)
         assert "max-age=60" in resp.headers["Cache-Control"]
+
+    def test_cache_expires_headers_are_not_sent_with_querystring(self):
+        resp = self.app.get(self.changes_uri + "?_since=0&_expected=42")
+        assert "max-age" not in resp.headers["Cache-Control"]

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -77,6 +77,13 @@ class UpdateChangesTest(BaseWebTest, unittest.TestCase):
                      headers={'If-None-Match': before_timestamp},
                      status=304)
 
+    def test_no_cache_control_is_returned_if_not_configured(self):
+        resp = self.app.get(self.changes_uri)
+        assert "max-age" not in resp.headers["Cache-Control"]
+
+        resp = self.app.get(self.changes_uri + '?_expected="42"')
+        assert "max-age" not in resp.headers["Cache-Control"]
+
     def test_returns_empty_list_if_no_resource_configured(self):
         with mock.patch.dict(self.app.app.registry.settings,
                              [('changes.resources', '')]):
@@ -142,12 +149,28 @@ class CacheExpiresTest(BaseWebTest, unittest.TestCase):
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings["monitor.changes.record_cache_expires_seconds"] = "60"
+        settings["monitor.changes.record_cache_maximum_expires_seconds"] = "3600"
         return settings
 
     def test_cache_expires_headers_are_supported(self):
         resp = self.app.get(self.changes_uri)
         assert "max-age=60" in resp.headers["Cache-Control"]
 
-    def test_cache_expires_headers_are_not_sent_with_querystring(self):
+    def test_cache_expires_header_is_maximum_with_cache_busting(self):
         resp = self.app.get(self.changes_uri + "?_since=0&_expected=42")
-        assert "max-age" not in resp.headers["Cache-Control"]
+        assert "max-age=3600" in resp.headers["Cache-Control"]
+
+    def test_cache_expires_header_is_default_with_filter(self):
+        # The _since just filters on lower bound of timestamps, if data changes
+        # we don't want to cache for too long.
+        resp = self.app.get(self.changes_uri + "?_since=0")
+        assert "max-age=60" in resp.headers["Cache-Control"]
+
+    def test_cache_expires_header_is_default_with_concurrency_control(self):
+        # The `If-None-Match` header is just a way to obtain a 304 instead of a 200
+        # with an empty list. In the client code [0] it is always used in conjonction
+        # with _since={last-etag}
+        # [0] https://searchfox.org/mozilla-central/rev/93905b66/services/settings/Utils.jsm#70-73
+        headers = {"If-None-Match": '"42"'}
+        resp = self.app.get(self.changes_uri + '?_since="42"', headers=headers)
+        assert "max-age=60" in resp.headers["Cache-Control"]


### PR DESCRIPTION
* In production we have `monitor.changes.record_cache_expires_seconds = 60`
* We have such a small value because we want clients that use Megaphone without cache busting (Fx 63) to get the freshest data we have
* CloudFront mainly relies on cache control headers sent by the application, and use the default configured value if none is set (1H in our case)
* Since we have a TTL of 1min on monitor/changes, every requests are refreshed every 1min, even the ones that could be cache a lot longer like the ones which contain `_since=` and `_expected=` for example. 
* This causes spikes of CPU when millions of clients receive a push notif and start synchronizing


This change is not ideal because it makes our kinto-changes code somehow coupled to our Cloudfront configuration (small TTL for monitor/changes, bigger TTL as default).

/cc @autrilla

