### PR TITLE
Add changeset endpoint (metadata + changes)

### DIFF
--- a/kinto_changes/__init__.py
+++ b/kinto_changes/__init__.py
@@ -13,6 +13,7 @@ CHANGES_COLLECTION = 'changes'
 CHANGES_COLLECTION_PATH = '{}/collections/{}'.format(
     MONITOR_BUCKET_PATH, CHANGES_COLLECTION)
 CHANGES_RECORDS_PATH = '{}/records'.format(CHANGES_COLLECTION_PATH)
+CHANGESET_PATH = '/buckets/{bid}/collections/{cid}/changeset'
 
 
 def identity(f):

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -178,7 +178,11 @@ def get_changeset(request):
     # Fetch current collection timestamp.
     timestamp = storage.resource_timestamp(resource_name="record", parent_id=collection_uri)
 
-    # XXX: Cache control headers.
+    # Cache control.
+    settings = request.registry.settings
+    cache_expires = settings.get(f"{bid}.{cid}.record_cache_expires_seconds")
+    if cache_expires is not None:
+        request.response.cache_expires(seconds=int(cache_expires))
 
     data = {
         "metadata": metadata,

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -143,6 +143,7 @@ class QuotedTimestamp(colander.SchemaNode):
 
 class ChangeSetQuerystring(colander.MappingSchema):
     _since = QuotedTimestamp(missing=colander.drop)
+    _expected = colander.SchemaNode(colander.String())
 
 
 class ChangeSetSchema(colander.MappingSchema):

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -194,4 +194,4 @@ def get_changeset(request):
         "timestamp": f'"{timestamp}"',
         "changes": changes,
     }
-    return {"data": data}
+    return data

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -4,12 +4,12 @@ from pyramid.security import IAuthorizationPolicy
 from zope.interface import implementer
 
 import kinto.core
-from kinto.authorization import AuthorizationPolicy, RouteFactory
+from kinto.authorization import RouteFactory
 from kinto.core import resource
 from kinto.core import utils as core_utils
 from kinto.core.storage import Filter
 from kinto.core.storage.memory import extract_object_set
-from kinto.core.utils import instance_uri, prefixed_principals, COMPARISON
+from kinto.core.utils import instance_uri, COMPARISON
 
 from .utils import monitored_collections, changes_object
 from . import CHANGESET_PATH, CHANGES_RECORDS_PATH, MONITOR_BUCKET, CHANGES_COLLECTION
@@ -123,8 +123,9 @@ class ChangeSetRoute(RouteFactory):
         self.required_permission = "read"
 
 
-changeset = kinto.core.Service(name='collection-changeset', path=CHANGESET_PATH, factory=ChangeSetRoute)
-
+changeset = kinto.core.Service(name='collection-changeset',
+                               path=CHANGESET_PATH,
+                               factory=ChangeSetRoute)
 
 
 class QuotedTimestamp(colander.SchemaNode):
@@ -189,4 +190,4 @@ def get_changeset(request):
         "timestamp": f'"{timestamp}"',
         "changes": changes,
     }
-    return { "data": data }
+    return {"data": data}

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -1,14 +1,18 @@
 import colander
+from cornice.validators import colander_validator
 from pyramid.security import IAuthorizationPolicy
 from zope.interface import implementer
 
+import kinto.core
+from kinto.authorization import AuthorizationPolicy, RouteFactory
 from kinto.core import resource
 from kinto.core import utils as core_utils
-from kinto.core.authorization import RouteFactory
+from kinto.core.storage import Filter
 from kinto.core.storage.memory import extract_object_set
+from kinto.core.utils import instance_uri, prefixed_principals, COMPARISON
 
 from .utils import monitored_collections, changes_object
-from . import CHANGES_RECORDS_PATH, MONITOR_BUCKET, CHANGES_COLLECTION
+from . import CHANGESET_PATH, CHANGES_RECORDS_PATH, MONITOR_BUCKET, CHANGES_COLLECTION
 
 
 class ChangesModel(object):
@@ -104,3 +108,80 @@ class Changes(resource.Resource):
 
         if cache_expires is not None:
             response.cache_expires(seconds=int(cache_expires))
+
+
+@implementer(IAuthorizationPolicy)
+class ChangeSetRoute(RouteFactory):
+
+    def __init__(self, request):
+        super().__init__(request)
+
+        bid = request.matchdict["bid"]
+        cid = request.matchdict["cid"]
+        collection_uri = instance_uri(request, "collection", bucket_id=bid, id=cid)
+        self.permission_object_id = collection_uri
+        self.required_permission = "read"
+
+
+changeset = kinto.core.Service(name='collection-changeset', path=CHANGESET_PATH, factory=ChangeSetRoute)
+
+
+
+class QuotedTimestamp(colander.SchemaNode):
+    """Integer between "" used in _since querystring."""
+
+    schema_type = colander.String
+    error_message = "The value should be integer between double quotes."
+    validator = colander.Regex('^"([0-9]+?)"$|\\*', msg=error_message)
+
+    def deserialize(self, cstruct=colander.null):
+        param = super(QuotedTimestamp, self).deserialize(cstruct)
+        if param is colander.drop:
+            return param
+        return int(param[1:-1])
+
+
+class ChangeSetQuerystring(colander.MappingSchema):
+    _since = QuotedTimestamp(missing=colander.drop)
+
+
+class ChangeSetSchema(colander.MappingSchema):
+    querystring = ChangeSetQuerystring()
+
+
+@changeset.get(schema=ChangeSetSchema(), permission="read", validators=(colander_validator,))
+def get_changeset(request):
+    bid = request.matchdict["bid"]
+    cid = request.matchdict["cid"]
+    bucket_uri = instance_uri(request, "bucket", id=bid)
+    collection_uri = instance_uri(request, "collection", bucket_id=bid, id=cid)
+
+    queryparams = request.validated["querystring"]
+    filters = []
+    if "_since" in queryparams:
+        filters = [Filter('last_modified', queryparams["_since"], COMPARISON.GT)]
+
+    storage = request.registry.storage
+
+    # Fetch collection metadata.
+    metadata = storage.get(resource_name="collection", parent_id=bucket_uri, object_id=cid)
+    # Fetch list of changes.
+    changes = storage.list_all(
+        resource_name="record",
+        parent_id=collection_uri,
+        filters=filters,
+        id_field='id',
+        modified_field='last_modified',
+        deleted_field='deleted',
+    )
+    # Fetch current collection timestamp.
+    timestamp = storage.resource_timestamp(resource_name="record", parent_id=collection_uri)
+
+    # XXX: Cache control headers.
+
+    data = {
+        "metadata": metadata,
+        "timestamp": f'"{timestamp}"',
+        "changes": changes,
+    }
+    return { "data": data }

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -112,13 +112,17 @@ class Changes(resource.Resource):
 
 @implementer(IAuthorizationPolicy)
 class ChangeSetRoute(RouteFactory):
+    """The changeset endpoint should have the same permissions as the collection
+    metadata.
 
+    The permission to read records is implicit when metadata are readable.
+    """
     def __init__(self, request):
         super().__init__(request)
-
         bid = request.matchdict["bid"]
         cid = request.matchdict["cid"]
         collection_uri = instance_uri(request, "collection", bucket_id=bid, id=cid)
+        # This route context will be the same as when reaching the collection URI.
         self.permission_object_id = collection_uri
         self.required_permission = "read"
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,7 +41,3 @@ class BaseWebTest(CoreWebTest):
         self.app.put_json(collection_uri,
                           {},
                           headers=self.headers)
-
-    def get_record_uri(self, bucket_id, collection_id, record_id):
-        return ('/buckets/{bucket_id}/collections/{collection_id}'
-                '/records/{record_id}').format(**locals())

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -16,6 +16,11 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         super(ChangesetViewTest, self).setUp()
         self.app.post_json(self.records_uri, SAMPLE_RECORD,
                            headers=self.headers)
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings["blocklists.certificates.record_cache_expires_seconds"] = 1234
+        return settings
 
     def test_changeset_is_accessible(self):
         resp = self.app.head(self.records_uri, headers=self.headers)
@@ -69,3 +74,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
 
     def test_extra_param_is_allowed(self):
         self.app.get(self.changeset_uri + "&_extra=abc", headers=self.headers)
+
+    def test_cache_control_headers_are_set(self):
+        resp = self.app.get(self.changeset_uri, headers=self.headers)
+        assert resp.headers['Cache-Control'] == 'max-age=1234'

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -1,0 +1,71 @@
+import unittest
+
+from . import BaseWebTest
+from kinto.core.testing import get_user_headers
+
+
+SAMPLE_RECORD = {'data': {'dev-edition': True}}
+
+
+class ChangesetViewTest(BaseWebTest, unittest.TestCase):
+    changes_uri = '/buckets/monitor/collections/changes/records'
+    records_uri = '/buckets/blocklists/collections/certificates/records'
+    changeset_uri = '/buckets/blocklists/collections/certificates/changeset'
+
+    def setUp(self):
+        super(ChangesetViewTest, self).setUp()
+        self.app.post_json(self.records_uri, SAMPLE_RECORD,
+                           headers=self.headers)
+
+    def test_changeset_is_accessible(self):
+        resp = self.app.head(self.records_uri, headers=self.headers)
+        etag = resp.headers["ETag"]
+
+        resp = self.app.get(self.changeset_uri, headers=self.headers)
+        data = resp.json["data"]
+        
+        assert "metadata" in data
+        assert "timestamp" in data
+        assert "changes" in data
+        assert data["metadata"]["id"] == "certificates"
+        assert len(data["changes"]) == 1
+        assert data["changes"][0]["dev-edition"] == True
+        assert data["timestamp"] == etag
+
+    def test_changeset_can_be_filtered(self):
+        resp = self.app.post_json(self.records_uri, {}, headers=self.headers)
+        before = resp.json["data"]["last_modified"]
+        self.app.post_json(self.records_uri, {}, headers=self.headers)
+
+        resp =self.app.get(self.changeset_uri, headers=self.headers)
+        assert len(resp.json["data"]["changes"]) == 3
+
+        resp =self.app.get(self.changeset_uri + f'?_since="{before}"', headers=self.headers)
+        assert len(resp.json["data"]["changes"]) == 1
+
+    def test_changeset_is_not_publicly_accessible(self):
+        # By default other users cannot read.
+        user_headers = {
+            **self.headers,
+            **get_user_headers('some-user'),
+        }
+        self.app.get(self.changeset_uri, status=401)
+        self.app.get(self.changeset_uri, headers=user_headers, status=403)
+
+        # Add read permissions to everyone.
+        self.app.patch_json("/buckets/blocklists", {
+            "permissions": {
+                "read": ["system.Everyone"]
+            }
+        }, headers=self.headers)
+
+        self.app.get(self.changeset_uri, headers=user_headers, status=200)
+        self.app.get(self.changeset_uri, status=200)
+
+    def test_timestamp_is_validated(self):
+        self.app.get(self.changeset_uri + "?_since=abc", headers=self.headers, status=400)
+        self.app.get(self.changeset_uri + "?_since=42", headers=self.headers, status=400)
+        self.app.get(self.changeset_uri + '?_since="42"', headers=self.headers)
+
+    def test_extra_param_is_allowed(self):
+        self.app.get(self.changeset_uri + '?_expected="42"', headers=self.headers)

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -16,6 +16,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         super(ChangesetViewTest, self).setUp()
         self.app.post_json(self.records_uri, SAMPLE_RECORD,
                            headers=self.headers)
+
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
@@ -28,13 +29,13 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
 
         resp = self.app.get(self.changeset_uri, headers=self.headers)
         data = resp.json["data"]
-        
+
         assert "metadata" in data
         assert "timestamp" in data
         assert "changes" in data
         assert data["metadata"]["id"] == "certificates"
         assert len(data["changes"]) == 1
-        assert data["changes"][0]["dev-edition"] == True
+        assert data["changes"][0]["dev-edition"] is True
         assert data["timestamp"] == etag
 
     def test_changeset_can_be_filtered(self):
@@ -42,10 +43,10 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         before = resp.json["data"]["last_modified"]
         self.app.post_json(self.records_uri, {}, headers=self.headers)
 
-        resp =self.app.get(self.changeset_uri, headers=self.headers)
+        resp = self.app.get(self.changeset_uri, headers=self.headers)
         assert len(resp.json["data"]["changes"]) == 3
 
-        resp =self.app.get(self.changeset_uri + f'&_since="{before}"', headers=self.headers)
+        resp = self.app.get(self.changeset_uri + f'&_since="{before}"', headers=self.headers)
         assert len(resp.json["data"]["changes"]) == 1
 
     def test_changeset_is_not_publicly_accessible(self):

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -10,7 +10,7 @@ SAMPLE_RECORD = {'data': {'dev-edition': True}}
 class ChangesetViewTest(BaseWebTest, unittest.TestCase):
     changes_uri = '/buckets/monitor/collections/changes/records'
     records_uri = '/buckets/blocklists/collections/certificates/records'
-    changeset_uri = '/buckets/blocklists/collections/certificates/changeset'
+    changeset_uri = '/buckets/blocklists/collections/certificates/changeset?_expected=42'
 
     def setUp(self):
         super(ChangesetViewTest, self).setUp()
@@ -40,7 +40,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         resp =self.app.get(self.changeset_uri, headers=self.headers)
         assert len(resp.json["data"]["changes"]) == 3
 
-        resp =self.app.get(self.changeset_uri + f'?_since="{before}"', headers=self.headers)
+        resp =self.app.get(self.changeset_uri + f'&_since="{before}"', headers=self.headers)
         assert len(resp.json["data"]["changes"]) == 1
 
     def test_changeset_is_not_publicly_accessible(self):
@@ -63,9 +63,9 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         self.app.get(self.changeset_uri, status=200)
 
     def test_timestamp_is_validated(self):
-        self.app.get(self.changeset_uri + "?_since=abc", headers=self.headers, status=400)
-        self.app.get(self.changeset_uri + "?_since=42", headers=self.headers, status=400)
-        self.app.get(self.changeset_uri + '?_since="42"', headers=self.headers)
+        self.app.get(self.changeset_uri + "&_since=abc", headers=self.headers, status=400)
+        self.app.get(self.changeset_uri + "&_since=42", headers=self.headers, status=400)
+        self.app.get(self.changeset_uri + '&_since="42"', headers=self.headers)
 
     def test_extra_param_is_allowed(self):
-        self.app.get(self.changeset_uri + '?_expected="42"', headers=self.headers)
+        self.app.get(self.changeset_uri + "&_extra=abc", headers=self.headers)

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -27,7 +27,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         etag = resp.headers["ETag"]
 
         resp = self.app.get(self.changeset_uri, headers=self.headers)
-        data = resp.json["data"]
+        data = resp.json
 
         assert "metadata" in data
         assert "timestamp" in data
@@ -43,10 +43,10 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         self.app.post_json(self.records_uri, {}, headers=self.headers)
 
         resp = self.app.get(self.changeset_uri, headers=self.headers)
-        assert len(resp.json["data"]["changes"]) == 3
+        assert len(resp.json["changes"]) == 3
 
         resp = self.app.get(self.changeset_uri + f'&_since="{before}"', headers=self.headers)
-        assert len(resp.json["data"]["changes"]) == 1
+        assert len(resp.json["changes"]) == 1
 
     def test_changeset_is_not_publicly_accessible(self):
         # By default other users cannot read.

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -8,7 +8,6 @@ SAMPLE_RECORD = {'data': {'dev-edition': True}}
 
 
 class ChangesetViewTest(BaseWebTest, unittest.TestCase):
-    changes_uri = '/buckets/monitor/collections/changes/records'
     records_uri = '/buckets/blocklists/collections/certificates/records'
     changeset_uri = '/buckets/blocklists/collections/certificates/changeset?_expected=42'
 
@@ -72,6 +71,9 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         self.app.get(self.changeset_uri + "&_since=abc", headers=self.headers, status=400)
         self.app.get(self.changeset_uri + "&_since=42", headers=self.headers, status=400)
         self.app.get(self.changeset_uri + '&_since="42"', headers=self.headers)
+
+    def test_expected_param_is_mandatory(self):
+        self.app.get(self.changeset_uri.split("?")[0], headers=self.headers, status=400)
 
     def test_extra_param_is_allowed(self):
         self.app.get(self.changeset_uri + "&_extra=abc", headers=self.headers)


### PR DESCRIPTION
Using a single endpoint instead of two, and thus having a single request instead of the current «two steps» synchronization, should prevent race conditions from happening. 
 
We expose a new endpoint (eg. /buckets/{bid}/collections/{cid}/changeset) that returns both metadata and changes in one response.
```
{
  "data": {
    "changes": [{
        "id": "88687994-5344-11ea-8e6c-472e7b6636b2",
        "last_modified": ...
      },
      …
    ],
    "metadata": {
      …
    }
}
```

The changes would be filtered using `?_since=<>` as usual.
The latest version will always be returned (latest metadata, latest changes since provided timestamp).

---------------------

* [x] Basic endpoint
* [x] Add cache control
* [ ] Update documentation