### PR TITLE
Bypass database on _since redirect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 3.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Bypass storage when redirecting on old ``_since``
 
 
 3.1.0 (2020-09-22)

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -92,13 +92,9 @@ class Changes(resource.Resource):
     def __init__(self, request, context=None):
         # Bypass call to storage if _since is too old.
         _handle_old_since_redirect(request)
-
-        super(Changes, self).__init__(request, context)
+        # Inject custom model.
         self.model = ChangesModel(request)
-
-    @property
-    def timestamp(self):
-        return self.model.timestamp()
+        super(Changes, self).__init__(request, context)
 
     def plural_get(self):
         result = super().plural_get()

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -138,7 +138,7 @@ def _handle_old_since_redirect(request):
         # we want to bypass storage).
         qs_since_str = request.GET.get("_since", "")
         qs_since = int(qs_since_str.strip('"'))
-    except (TypeError, ValueError):
+    except ValueError:
         # Will fail later during resource querystring validation.
         return
 


### PR DESCRIPTION
In #205 we decided to redirect clients coming in with an old `_since` value, in order to preserve our server resources.

This PR is a follow-up that makes sure we bypass the database (should have been the case if the author of #205 would have been more thorough)


@smarnach r?
