### PR TITLE
Fix crash when quoted timestamp contains new-line (fixes #293)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix crash when quoted timestamp contains new-line (fixes #293)
 
 
 4.1.0 (2021-10-28)

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -235,7 +235,7 @@ class QuotedTimestamp(colander.SchemaNode):
 
     schema_type = colander.String
     error_message = "The value should be integer between double quotes."
-    validator = colander.Regex('^"[0-9]+"\Z', msg=error_message)
+    validator = colander.Regex('^"[0-9]+"(?!\n)$', msg=error_message)
 
     def deserialize(self, cstruct=colander.null):
         param = super(QuotedTimestamp, self).deserialize(cstruct)

--- a/kinto_changes/views.py
+++ b/kinto_changes/views.py
@@ -235,7 +235,7 @@ class QuotedTimestamp(colander.SchemaNode):
 
     schema_type = colander.String
     error_message = "The value should be integer between double quotes."
-    validator = colander.Regex('^"([0-9]+?)"$', msg=error_message)
+    validator = colander.Regex('^"[0-9]+"\Z', msg=error_message)
 
     def deserialize(self, cstruct=colander.null):
         param = super(QuotedTimestamp, self).deserialize(cstruct)

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -129,6 +129,10 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
             )
             self.app.get(changeset_uri, headers=self.headers, status=503)
 
+    def test_since_param_cannot_contain_newline(self):
+        invalid_param = self.changeset_uri + "&_since=\"1572620201554\"\n"
+        self.app.get(invalid_param, headers=self.headers, status=400)
+
 
 class ReadonlyTest(BaseWebTest, unittest.TestCase):
     changeset_uri = "/buckets/monitor/collections/changes/changeset?_expected=42"

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -130,7 +130,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
             self.app.get(changeset_uri, headers=self.headers, status=503)
 
     def test_since_param_cannot_contain_newline(self):
-        invalid_param = self.changeset_uri + "&_since=\"1572620201554\"\n"
+        invalid_param = self.changeset_uri + '&_since="1572620201554"\n'
         self.app.get(invalid_param, headers=self.headers, status=400)
 
 


### PR DESCRIPTION
Fixes #293

See https://sentry.prod.mozaws.net/operations/kinto-prod-1/issues/14568681/

Alternatively we could trim the new line, but since our clients aren't supposed to send it, I went for returning a `HTTP 400`